### PR TITLE
Simplify the Swift code

### DIFF
--- a/RottenTomatoesSwift/RottenTomatoesSwift/AppDelegate.swift
+++ b/RottenTomatoesSwift/RottenTomatoesSwift/AppDelegate.swift
@@ -13,34 +13,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
-
-    func applicationWillResignActive(application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(application: UIApplication) {
-        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
 
 }
 

--- a/RottenTomatoesSwift/RottenTomatoesSwift/Movie.swift
+++ b/RottenTomatoesSwift/RottenTomatoesSwift/Movie.swift
@@ -15,26 +15,23 @@ struct Movie {
 }
 
 extension Movie {
-    static func moviesFromDictionaryArray(dictionaryArray: [NSDictionary]) -> [Movie]? {
-        var movieArray = [Movie]()
+    static func moviesFromMovieDescriptions(listOfMovieDescriptions: [NSDictionary]) -> [Movie]? {
+        var movies = [Movie]()
         
-        for dictionary in dictionaryArray {
-            if let posterDictionary = dictionary["posters"] as? NSDictionary,
-                let posterURLString = posterDictionary["thumbnail"] as? String,
-                let posterURL = NSURL(string: posterURLString) {
-                    
-                    let movieTitle = dictionary["title"] as? String ?? "Title Not Found"
-                    let movieDescription = dictionary["synopsis"] as? String ?? "Synopsys Not Found"
-                    
-                    movieArray += [Movie(title: movieTitle, description: movieDescription, posterURL: posterURL)]
+        for movieDescription in listOfMovieDescriptions {
+            guard let posterDictionary = movieDescription["posters"] as? NSDictionary,
+                  let posterURLString = posterDictionary["thumbnail"] as? String,
+                  let posterURL = NSURL(string: posterURLString) else {
+                continue
             }
+                    
+            let movieTitle = movieDescription["title"] as? String ?? "Title Not Found"
+            let description = movieDescription["synopsis"] as? String ?? "Synopsis Not Found"
+            
+            movies.append(Movie(title: movieTitle, description: description, posterURL: posterURL))
         }
         
-        if movieArray.isEmpty == false {
-            return movieArray
-        } else {
-            return .None
-        }
+        return movies
     }
 }
 


### PR DESCRIPTION
* Remove unused delegate methods in appdelegate
* Use closure instead of delegate for Downloader. This removes the
  requirement for iterating through cells to update its data, since
  the closure already captures the cell. Also makes it easier to
  separate json downloads from image downloads.
* Use guard in moviesFromMovieDescriptions
* Remove some error handling. The error handling makes the code very
  hard to read. Better to add error handling as an extra step for
  students that want a challenge.